### PR TITLE
refactor : 응답 파싱 책임을 PurchaseResponse 객체로 이동

### DIFF
--- a/src/main/java/com/pintoss/auth/module/order/integration/PurchaseResponse.java
+++ b/src/main/java/com/pintoss/auth/module/order/integration/PurchaseResponse.java
@@ -1,5 +1,9 @@
 package com.pintoss.auth.module.order.integration;
 
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +35,58 @@ public class PurchaseResponse {
     private String printMsg4;
     private String printFlag5;
     private String printMsg5;
+
+    public static PurchaseResponse fromBytes(byte[] plainBytes)
+        throws UnsupportedEncodingException {
+        PurchaseResponse res = new PurchaseResponse();
+        int idx = 0;
+
+        try {
+            res.setResponseCode(readField(plainBytes, idx, 4)); idx += 4;
+            res.setSuccess("0000".equals(res.getResponseCode()));
+            res.setApprovalCode(readField(plainBytes, idx, 32)); idx += 32;
+            res.setOpenFlag(readField(plainBytes, idx, 1)); idx += 1;
+            res.setCardNo(readField(plainBytes, idx, 32)); idx += 32;
+            res.setRemainPrice(readField(plainBytes, idx, 8)); idx += 8;
+            res.setItemName(readField(plainBytes, idx, 32)); idx += 32;
+
+            res.setPrintFlag1(readField(plainBytes, idx, 1)); idx += 1;
+            res.setPrintMsg1(readField(plainBytes, idx, 32)); idx += 32;
+            if(res.getItemName().equals("도서문화상품권")) {
+                String msg = res.getPrintMsg1();
+                Matcher matcher = Pattern.compile("비밀번호[:：\\s]*([0-9]{4})").matcher(msg);
+                if(matcher.find()) {
+                    String password = matcher.group(1); // 괄호로 캡처한 숫자 4자리
+                    res.setCardNo(res.getCardNo()+"-"+password);
+                }
+            }
+            res.setPrintFlag2(readField(plainBytes, idx, 1)); idx += 1;
+            res.setPrintMsg2(readField(plainBytes, idx, 32)); idx += 32;
+
+            res.setPrintFlag3(readField(plainBytes, idx, 1)); idx += 1;
+            res.setPrintMsg3(readField(plainBytes, idx, 32)); idx += 32;
+
+            res.setPrintFlag4(readField(plainBytes, idx, 1)); idx += 1;
+            res.setPrintMsg4(readField(plainBytes, idx, 32)); idx += 32;
+
+            res.setPrintFlag5(readField(plainBytes, idx, 1)); idx += 1;
+            res.setPrintMsg5(readField(plainBytes, idx, 32)); idx += 32;
+
+            log.debug("[Galaxia 응답] 승인번호: {}, 카드번호: {}, 잔액: {}, 상품명: {}, 응답코드: {}",
+                res.getApprovalCode(), res.getCardNo(), res.getRemainPrice(), res.getItemName(), res.getResponseCode());
+        } catch (Exception e) {
+            log.error("Galaxia 응답 파싱 중 오류 발생 : {}", e.getMessage(), e);
+            res.setSuccess(false);
+        }
+        return res;
+    }
+
+    private static String readField(byte[] bytes, int offset, int length) throws UnsupportedEncodingException{
+        if (offset + length > bytes.length) {
+            throw new IndexOutOfBoundsException("바이트 배열 범위를 초과했습니다: offset=" + offset + ", length=" + length);
+        }
+        return new String(Arrays.copyOfRange(bytes, offset, offset + length), "EUC-KR").trim();
+    }
 
 }
 


### PR DESCRIPTION
### 이슈 번호
- #10 

<br>

### 작업 내용
- [x] 응답 파싱 책임을 PurchaseResponse 객체로 이동
