### PR TITLE
refactor : 애플리케이션 계층에서 이벤트 발행 시 Spring에 대한 의존성 제거

### DIFF
--- a/src/main/java/com/pintoss/auth/api/event/VoucherPurchaseRequestEventHandler.java
+++ b/src/main/java/com/pintoss/auth/api/event/VoucherPurchaseRequestEventHandler.java
@@ -1,7 +1,7 @@
 package com.pintoss.auth.api.event;
 
 
-import com.pintoss.auth.common.event.VoucherPurchaseEvent;
+import com.pintoss.auth.common.event.VoucherPurchaseRequestEvent;
 import com.pintoss.auth.common.logging.LogContext;
 import com.pintoss.auth.core.voucher.application.VoucherPurchaseService;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +12,12 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class VoucherPurchaseEventHandler {
+public class VoucherPurchaseRequestEventHandler {
 
     private final VoucherPurchaseService voucherPurchaseService;
 
     @EventListener
-    public void handle(VoucherPurchaseEvent event) {
+    public void handle(VoucherPurchaseRequestEvent event) {
         LogContext.putPurchaseRequest(
             event.getOrderNo(),
             event.getOrderItemId(),

--- a/src/main/java/com/pintoss/auth/common/event/VoucherPurchaseRequestEvent.java
+++ b/src/main/java/com/pintoss/auth/common/event/VoucherPurchaseRequestEvent.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class VoucherPurchaseEvent {
+public class VoucherPurchaseRequestEvent {
     private final String orderNo;
     private final Long orderItemId;
     private final String transactionId;

--- a/src/main/java/com/pintoss/auth/core/order/application/OrderEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/core/order/application/OrderEventPublisher.java
@@ -1,0 +1,7 @@
+package com.pintoss.auth.core.order.application;
+
+import com.pintoss.auth.common.event.VoucherPurchaseRequestEvent;
+
+public interface OrderEventPublisher {
+    void publish(VoucherPurchaseRequestEvent voucherPurchaseRequestEvent);
+}

--- a/src/main/java/com/pintoss/auth/core/order/application/OrderPaymentResultService.java
+++ b/src/main/java/com/pintoss/auth/core/order/application/OrderPaymentResultService.java
@@ -1,11 +1,10 @@
 package com.pintoss.auth.core.order.application;
 
-import com.pintoss.auth.common.event.VoucherPurchaseEvent;
+import com.pintoss.auth.common.event.VoucherPurchaseRequestEvent;
 import com.pintoss.auth.core.order.application.flow.OrderReader;
 import com.pintoss.auth.core.order.domain.Order;
 import com.pintoss.auth.core.order.domain.OrderItem;
 import com.pintoss.auth.core.payment.application.PaymentMethodType;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderPaymentResultService {
 
     private final OrderReader orderReader;
-    private final ApplicationEventPublisher eventPublisher;
+    private final OrderEventPublisher eventPublisher;
 
-    public OrderPaymentResultService(OrderReader orderReader, ApplicationEventPublisher eventPublisher) {
+    public OrderPaymentResultService(OrderReader orderReader, OrderEventPublisher eventPublisher) {
         this.orderReader = orderReader;
         this.eventPublisher = eventPublisher;
     }
@@ -34,7 +33,7 @@ public class OrderPaymentResultService {
         order.markAsPaid(paymentId);
 
         for(OrderItem item : order.getOrderItems()) {
-            VoucherPurchaseEvent voucherPurchaseEvent = new VoucherPurchaseEvent(
+            VoucherPurchaseRequestEvent voucherPurchaseRequestEvent = new VoucherPurchaseRequestEvent(
                 orderNo,
                 item.getId(),
                 transactionId,
@@ -45,7 +44,7 @@ public class OrderPaymentResultService {
                 item.getProductCode()
             );
 
-            eventPublisher.publishEvent(voucherPurchaseEvent);
+            eventPublisher.publish(voucherPurchaseRequestEvent);
         }
     }
 }

--- a/src/main/java/com/pintoss/auth/core/payment/application/PaymentEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/core/payment/application/PaymentEventPublisher.java
@@ -1,0 +1,8 @@
+package com.pintoss.auth.core.payment.application;
+
+import com.pintoss.auth.common.event.PaymentCompletedEvent;
+
+public interface PaymentEventPublisher {
+
+    void publish(PaymentCompletedEvent paymentCompletedEvent);
+}

--- a/src/main/java/com/pintoss/auth/core/payment/application/PaymentService.java
+++ b/src/main/java/com/pintoss/auth/core/payment/application/PaymentService.java
@@ -17,7 +17,7 @@ public class PaymentService {
     private final PaymentApprovalService paymentApprovalService;
     private final OrderReader orderReader;
     private final PaymentAdder paymentAdder;
-    private final ApplicationEventPublisher eventPublisher;
+    private final PaymentEventPublisher eventPublisher;
 
     @Transactional
     public void purchase(PurchaseCommand command) {
@@ -42,7 +42,7 @@ public class PaymentService {
         );
         paymentAdder.add(payment);
 
-        eventPublisher.publishEvent(
+        eventPublisher.publish(
             new PaymentCompletedEvent(
                 payment.getStatus() == PaymentStatus.SUCCESS ? true : false,
                 payment.getId(),

--- a/src/main/java/com/pintoss/auth/core/voucher/application/VoucherPurchaseService.java
+++ b/src/main/java/com/pintoss/auth/core/voucher/application/VoucherPurchaseService.java
@@ -4,15 +4,16 @@ import com.pintoss.auth.client.galaxia.PurchaseApiClient;
 import com.pintoss.auth.common.event.VoucherPurchaseCompletedEvent;
 import com.pintoss.auth.core.order.domain.PurchaseResult;
 import com.pintoss.auth.core.payment.application.PaymentMethodType;
+import com.pintoss.auth.core.voucher.application.service.VoucherEventPublisher;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
 public class VoucherPurchaseService {
     private final PurchaseApiClient purchaseApiClient;
-    private final ApplicationEventPublisher eventPublisher;
+    private final VoucherEventPublisher eventPublisher;
 
-    public VoucherPurchaseService(PurchaseApiClient purchaseApiClient, ApplicationEventPublisher eventPublisher) {
+    public VoucherPurchaseService(PurchaseApiClient purchaseApiClient, VoucherEventPublisher eventPublisher) {
         this.purchaseApiClient = purchaseApiClient;
         this.eventPublisher = eventPublisher;
     }
@@ -39,7 +40,7 @@ public class VoucherPurchaseService {
 //                "1104501710200000"
         );
 
-        eventPublisher.publishEvent(
+        eventPublisher.publish(
             new VoucherPurchaseCompletedEvent(
                 result.isSuccess(),
                 orderNo,

--- a/src/main/java/com/pintoss/auth/core/voucher/application/service/VoucherEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/core/voucher/application/service/VoucherEventPublisher.java
@@ -1,0 +1,7 @@
+package com.pintoss.auth.core.voucher.application.service;
+
+import com.pintoss.auth.common.event.VoucherPurchaseCompletedEvent;
+
+public interface VoucherEventPublisher {
+    void publish(VoucherPurchaseCompletedEvent voucherPurchaseCompletedEvent);
+}

--- a/src/main/java/com/pintoss/auth/event/SpringOrderEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/event/SpringOrderEventPublisher.java
@@ -1,0 +1,21 @@
+package com.pintoss.auth.event;
+
+import com.pintoss.auth.common.event.VoucherPurchaseRequestEvent;
+import com.pintoss.auth.core.order.application.OrderEventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringOrderEventPublisher implements OrderEventPublisher {
+
+    private final ApplicationEventPublisher delegate;
+
+    public SpringOrderEventPublisher(ApplicationEventPublisher delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void publish(VoucherPurchaseRequestEvent voucherPurchaseRequestEvent) {
+        delegate.publishEvent(voucherPurchaseRequestEvent);
+    }
+}

--- a/src/main/java/com/pintoss/auth/event/SpringPaymentEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/event/SpringPaymentEventPublisher.java
@@ -1,0 +1,21 @@
+package com.pintoss.auth.event;
+
+import com.pintoss.auth.common.event.PaymentCompletedEvent;
+import com.pintoss.auth.core.payment.application.PaymentEventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringPaymentEventPublisher implements PaymentEventPublisher {
+
+    private final ApplicationEventPublisher delegate;
+
+    public SpringPaymentEventPublisher(ApplicationEventPublisher delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void publish(PaymentCompletedEvent paymentCompletedEvent) {
+        delegate.publishEvent(paymentCompletedEvent);
+    }
+}

--- a/src/main/java/com/pintoss/auth/event/SpringVoucherEventPublisher.java
+++ b/src/main/java/com/pintoss/auth/event/SpringVoucherEventPublisher.java
@@ -1,0 +1,21 @@
+package com.pintoss.auth.event;
+
+import com.pintoss.auth.common.event.VoucherPurchaseCompletedEvent;
+import com.pintoss.auth.core.voucher.application.service.VoucherEventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringVoucherEventPublisher implements VoucherEventPublisher {
+
+    private final ApplicationEventPublisher delegate;
+
+    public SpringVoucherEventPublisher(ApplicationEventPublisher delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void publish(VoucherPurchaseCompletedEvent voucherPurchaseCompletedEvent) {
+        delegate.publishEvent(voucherPurchaseCompletedEvent);
+    }
+}


### PR DESCRIPTION
### 이슈 번호
- #35 

### 작업 내용
- [x] 결제 완료 이벤트 발행 추상화 
- [x] 상품권 구매 요청 이벤트 발행 추상화
- [x] 상품권 구매 완료 요청 이벤트 발행 추상화
- [x] 상품권 구매 요청 이벤트 클래스 명 수정 ( `VoucherPurchaseEvent` -> `VoucherPurchaseRequestEvent`)