### PR TITLE
fix : Core 관련 에러 로그 레벨 수정

### DIFF
--- a/src/main/java/com/pintoss/auth/api/support/api/WebInterceptorConfig.java
+++ b/src/main/java/com/pintoss/auth/api/support/api/WebInterceptorConfig.java
@@ -1,11 +1,8 @@
 package com.pintoss.auth.api.support.api;
 
 import com.pintoss.auth.api.support.interceptor.AuthorizationInterceptor;
-import com.pintoss.auth.api.support.filter.MdcLoggingFilter;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/src/main/java/com/pintoss/auth/api/support/exception/handler/ClientExceptionHandler.java
+++ b/src/main/java/com/pintoss/auth/api/support/exception/handler/ClientExceptionHandler.java
@@ -30,7 +30,7 @@ public class ClientExceptionHandler {
     private ResponseEntity<ApiErrorResponse> buildError(BaseException e, HttpServletRequest request) {
         LocalDateTime timestamp = LocalDateTime.now();
         ApiErrorResponse errorResponse = ApiErrorResponse.of(e.getHttpStatus(), e.getErrorCode().getCode(), e.getErrorCode().getMessage(), timestamp);
-        log.error("[ClientException] errorCode={}, message={}, path={}, method={}, time={}",
+        log.warn("[ClientException] errorCode={}, message={}, path={}, method={}, time={}",
                 e.getErrorCode(), e.getMessage(), request.getRequestURI(), request.getMethod(), DateTimeUtils.formatKorean(timestamp));
         return new ResponseEntity<>(errorResponse, e.getHttpStatus());
     }

--- a/src/main/java/com/pintoss/auth/api/support/exception/handler/CoreExceptionHandler.java
+++ b/src/main/java/com/pintoss/auth/api/support/exception/handler/CoreExceptionHandler.java
@@ -2,10 +2,10 @@ package com.pintoss.auth.api.support.exception.handler;
 
 import com.pintoss.auth.api.support.dto.ApiErrorResponse;
 import com.pintoss.auth.api.support.util.DateTimeUtils;
-import com.pintoss.auth.core.exception.*;
+import com.pintoss.auth.core.exception.CoreException;
+import com.pintoss.auth.core.exception.HttpErrorType;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -16,13 +16,16 @@ import java.time.LocalDateTime;
 @ControllerAdvice
 @Slf4j
 public class CoreExceptionHandler {
+    /**
+     * TODO : 결제 관련 예외 => error 레벨 수정 필요
+     */
 
     @ExceptionHandler({CoreException.class})
     public final ResponseEntity<ApiErrorResponse> handleCoreExceptions(CoreException e, HttpServletRequest request) {
         LocalDateTime timestamp = LocalDateTime.now();
         HttpStatus status = resolveHttpStatus(e.getErrorCode().getHttpErrorType());
         ApiErrorResponse errorResponse = ApiErrorResponse.of(status, e.getErrorCode().getCode(), e.getErrorCode().getMessage(), timestamp);
-        log.error("[CoreException] errorCode={}, message={}, path={}, method={}, time={}",
+        log.warn("[CoreException] errorCode={}, message={}, path={}, method={}, time={}",
                 e.getErrorCode(), e.getMessage(), request.getRequestURI(), request.getMethod(), DateTimeUtils.formatKorean(timestamp));
         return new ResponseEntity<>(errorResponse, status);
     }

--- a/src/main/java/com/pintoss/auth/api/support/exception/handler/SecurityExceptionHandler.java
+++ b/src/main/java/com/pintoss/auth/api/support/exception/handler/SecurityExceptionHandler.java
@@ -23,18 +23,18 @@ public class SecurityExceptionHandler {
 
     @ExceptionHandler(value = {AuthorizationDeniedException.class})
     public final ResponseEntity<ApiErrorResponse> handleAccessDenied(AuthorizationDeniedException e, HttpServletRequest request) {
-        return error(ErrorCode.AUTH_ACCESS_DENIED, HttpStatus.FORBIDDEN, e, request);
+        return warn(ErrorCode.AUTH_ACCESS_DENIED, HttpStatus.FORBIDDEN, e, request);
     }
 
     @ExceptionHandler(value = {AuthenticationException.class, UsernameNotFoundException.class, BadCredentialsException.class})
     public ResponseEntity<ApiErrorResponse> handleAuthenticationException(Exception e, HttpServletRequest request) {
-        return error(ErrorCode.UNAUTHORIZED, HttpStatus.BAD_REQUEST, e, request);
+        return warn(ErrorCode.UNAUTHORIZED, HttpStatus.BAD_REQUEST, e, request);
     }
 
-    private ResponseEntity<ApiErrorResponse> error(ErrorCode code, HttpStatus status, Exception e, HttpServletRequest request) {
+    private ResponseEntity<ApiErrorResponse> warn(ErrorCode code, HttpStatus status, Exception e, HttpServletRequest request) {
         LocalDateTime timestamp = LocalDateTime.now();
         ApiErrorResponse errorResponse = ApiErrorResponse.of(status, code.getCode(), code.getMessage(), timestamp);
-        log.error("[SecurityException] errorCode={}, message={}, path={}, method={}, time={}",
+        log.warn("[SecurityException] errorCode={}, message={}, path={}, method={}, time={}",
                 code,
                 e.getMessage(),
                 request.getRequestURI(),

--- a/src/main/java/com/pintoss/auth/api/support/exception/handler/ValidationExceptionHandler.java
+++ b/src/main/java/com/pintoss/auth/api/support/exception/handler/ValidationExceptionHandler.java
@@ -32,7 +32,7 @@ public class ValidationExceptionHandler {
         }
         ApiErrorResponse errorResponse = ApiErrorResponse.withErrors(
                 HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), "유효하지 않은 요청입니다", errors);
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
@@ -42,7 +42,7 @@ public class ValidationExceptionHandler {
         e.getConstraintViolations().forEach(v -> errors.put(v.getPropertyPath().toString(), v.getMessage()));
         ApiErrorResponse errorResponse = ApiErrorResponse.withErrors(
                 HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), ErrorCode.BAD_REQUEST.getMessage(), errors);
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
@@ -59,7 +59,7 @@ public class ValidationExceptionHandler {
         }
         ApiErrorResponse errorResponse = ApiErrorResponse.of(
                 HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message, LocalDateTime.now());
-        log.error(e.getMessage());
+        log.warn(e.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/pintoss/auth/api/support/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/pintoss/auth/api/support/filter/MdcLoggingFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;

--- a/src/main/java/com/pintoss/auth/core/exception/CoreErrorCode.java
+++ b/src/main/java/com/pintoss/auth/core/exception/CoreErrorCode.java
@@ -18,6 +18,7 @@ public enum CoreErrorCode {
     // Order Item Errors
     ORDER_ITEM_ALREADY_ISSUED("40017", "이미 발급된 주문 아이템입니다.", HttpErrorType.BAD_REQUEST),
     ORDER_ITEM_NOT_FOUND("40018", "주문 항목을 찾을 수 없습니다.", HttpErrorType.NOT_FOUND),
+
     // Payment Errors
     PAYMENT_APPROVAL_FAILED("40011", "결제 승인이 거절되었습니다.", HttpErrorType.BAD_REQUEST),
     PAYMENT_APPROVED_AMOUNT_MISMATCH("40012", "결제 승인 금액이 주문 금액과 일치하지 않습니다.", HttpErrorType.BAD_REQUEST),


### PR DESCRIPTION
#49 

DB에서 데이터를 조회하지 못하거나 인증 과정에 실패했을 때의 로그가 error로 남는 것은 로그 레벨이 너무 높은 것 같습니다. 시스템에 즉각적인 장애로 이어지지 않는 문제에 대한 로그 레벨은 warn으로 남기는 것이 추후 로그를 구분하고 관리하기 좋을 것 같습니다.
서버 내부 에러나 외부 시스템 연동 관련 에러는 error로 남기고 사용자 요청에 의한 예외는 warn 레벨로 수정했습니다.