### PR TITLE
setting : cicd java distribution 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
 #
 #      - name: Set Application Properties
 #        run: |


### PR DESCRIPTION
유지보수성을 고려해 지원이 중단된 adopt distribution에서 temurin으로 변경
현재 adopt distribution 공식문서에서도 temurin으로의 변경을 권장하고 있어 java distribution을 변경하였습니다.

레퍼런스 : https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
